### PR TITLE
오른쪽 옵션키로 한/A 전환 추가

### DIFF
--- a/SokIM/HotKeyMonitor.swift
+++ b/SokIM/HotKeyMonitor.swift
@@ -67,6 +67,9 @@ class HotKeyMonitor {
             case .rightCommand:
                 debug("HotKey 해당 없음")
                 return
+            case .rightOption:
+                debug("HotKey 해당 없음")
+                return
             case .commandSpace:
                 code = UInt32(kVK_Space)
                 modifiers = UInt32(cmdKey)

--- a/SokIM/InputMonitor.swift
+++ b/SokIM/InputMonitor.swift
@@ -172,6 +172,12 @@ class InputMonitor {
                 appDelegate()?.statusBar.rotateEngine()
             }
 
+            // 별도 처리: 오른쪽 Option: 한/A 표시만 *우선 처리*, 실제 처리는 State에서
+            if (type, key) == (.keyDown, .rightOption)
+                && Preferences.rotateShortcuts.contains(.rightOption) {
+                appDelegate()?.statusBar.rotateEngine()
+            }
+
             // 별도 처리: Caps Lock: 한/A 상태 및 LED *우선 처리*, 실제 처리는 State에서
             if (type, key) == (.keyDown, .capsLock) {
                 if Preferences.rotateShortcuts.contains(.capsLock) {

--- a/SokIM/InputMonitor.swift
+++ b/SokIM/InputMonitor.swift
@@ -172,9 +172,10 @@ class InputMonitor {
                 appDelegate()?.statusBar.rotateEngine()
             }
 
-            // 별도 처리: 오른쪽 Option: 한/A 표시만 *우선 처리*, 실제 처리는 State에서
+            // 별도 처리: 오른쪽 Option: 조합 종료 후 한/A 표시만 *우선 처리*, 실제 처리는 State에서
             if (type, key) == (.keyDown, .rightOption)
                 && Preferences.rotateShortcuts.contains(.rightOption) {
+                appDelegate()?.commit()
                 appDelegate()?.statusBar.rotateEngine()
             }
 

--- a/SokIM/Preferences.swift
+++ b/SokIM/Preferences.swift
@@ -4,6 +4,7 @@ import Cocoa
 enum RotateShortcutType: String {
     case capsLock = "CapsLock"
     case rightCommand = "RightCommand"
+    case rightOption = "RightOption"
     case commandSpace = "CommandSpace"
     case shiftSpace = "ShiftSpace"
     case controlSpace = "ControlSpace"

--- a/SokIM/State.swift
+++ b/SokIM/State.swift
@@ -40,6 +40,12 @@ struct State: CustomStringConvertible {
                 rotate()
             }
 
+            // 오른쪽 Option: 한/A 전환 *실제 처리*
+            if (type, key) == (.keyDown, .rightOption)
+                && Preferences.rotateShortcuts.contains(.rightOption) {
+                rotate()
+            }
+
             // Caps Lock: 한/A 상태 및 LED *실제 처리*
             if (type, key) == (.keyDown, .capsLock) {
                 // 한/A 전환이 Caps Lock인 경우 처리

--- a/SokIM/StatusBar.swift
+++ b/SokIM/StatusBar.swift
@@ -27,6 +27,7 @@ class StatusBar {
 
     private let capsLockItem = NSMenuItem()
     private let rightCommandItem = NSMenuItem()
+    private let rightOptionItem = NSMenuItem()
     private let commandSpaceItem = NSMenuItem()
     private let shiftSpaceItem = NSMenuItem()
     private let controlSpaceItem = NSMenuItem()
@@ -84,6 +85,12 @@ class StatusBar {
         rightCommandItem.target = self
         rightCommandItem.action = #selector(toggleRightCommand)
         menu.addItem(rightCommandItem)
+
+        rightOptionItem.title = "오른쪽 ⌥"
+        rightOptionItem.state = Preferences.rotateShortcuts.contains(.rightOption) ? .on : .off
+        rightOptionItem.target = self
+        rightOptionItem.action = #selector(toggleRightOption)
+        menu.addItem(rightOptionItem)
 
         commandSpaceItem.title = "⌘스페이스"
         commandSpaceItem.state = Preferences.rotateShortcuts.contains(.commandSpace) ? .on : .off
@@ -213,6 +220,22 @@ class StatusBar {
         } else {
             rotateShortcuts.remove(.rightCommand)
             rightCommandItem.state = .off
+        }
+        Preferences.rotateShortcuts = rotateShortcuts
+
+        statusItem.button?.performClick(nil)
+    }
+
+    @objc func toggleRightOption(sender: NSMenuItem) {
+        debug()
+
+        var rotateShortcuts = Preferences.rotateShortcuts
+        if sender.state == .off {
+            rotateShortcuts.insert(.rightOption)
+            rightOptionItem.state = .on
+        } else {
+            rotateShortcuts.remove(.rightOption)
+            rightOptionItem.state = .off
         }
         Preferences.rotateShortcuts = rotateShortcuts
 


### PR DESCRIPTION
https://github.com/kiding/SokIM/issues/36

제 키보드에서는 한영전환키가 오른쪽 옵션키로 인식되고 있습니다
오른쪽 옵션키를 기존 코드와 비슷한 구조로 추가했습니다